### PR TITLE
Fix page number position

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ pdfs:
 
 pdfs/%.pdf : %.md
 	@mkdir -p "$(@D)"
-	pandoc --pdf-engine=xelatex -V geometry:margin=1cm -V geometry:a4paper $< -o $@
+	pandoc --pdf-engine=xelatex -V geometry:margin=1cm -V geometry:a4paper -V geometry:includefoot $< -o $@
 
 clean:
 	$(RM) -r pdfs


### PR DESCRIPTION
Let the footer that contains the page numbers be inside the margins by setting the option `/includefoot` to ensure it shows up on the page in the printable area. See [here](https://texdoc.org/serve/geometry.pdf/0), chapter 3 for the full documentation of the option and possible alternatives.